### PR TITLE
PR || Adds role-based access control with custom decorator and guard

### DIFF
--- a/src/auth/roles.decorator.ts
+++ b/src/auth/roles.decorator.ts
@@ -1,0 +1,7 @@
+// Decorator pattern: This custom decorator attaches role metadata to route handlers
+// for use by guards (OCP, SRP)
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../user/user.entity';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,31 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { UserRole } from '../user/user.entity';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    if (!user || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException(
+        'You do not have permission to perform this action',
+      );
+    }
+    return true;
+  }
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -13,6 +13,9 @@ import { UserService } from './user.service';
 import { User } from './user.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { UserRole } from './user.entity';
 
 @Controller('users')
 export class UserController {
@@ -45,7 +48,8 @@ export class UserController {
     return updated;
   }
 
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.ADMIN)
   @Delete(':id')
   async remove(
     @Param('id', ParseIntPipe) id: number,


### PR DESCRIPTION
Introduces a custom `Roles` decorator and `RolesGuard` to implement role-based access control for route handlers.

The `Roles` decorator attaches role metadata, while `RolesGuard` validates user permissions based on roles defined in the decorator. Updates the `UserController` to restrict the deletion endpoint to admin users.

Enhances security and maintains code modularity.