### PR TITLE
PR || Add role update endpoint with access control

### DIFF
--- a/src/user/dto/update-user-role.dto.ts
+++ b/src/user/dto/update-user-role.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserRole } from '../user.entity';
+
+export class UpdateUserRoleDto {
+  @IsEnum(UserRole)
+  role: UserRole;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -4,10 +4,14 @@ import {
   Param,
   Put,
   Delete,
+  Patch,
   UseGuards,
   Body,
+  Request,
   ParseIntPipe,
   NotFoundException,
+  UnauthorizedException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { User } from './user.entity';
@@ -16,6 +20,8 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { UserRole } from './user.entity';
+import { UpdateUserRoleDto } from './dto/update-user-role.dto';
+import { Request as ExpressRequest } from 'express';
 
 @Controller('users')
 export class UserController {
@@ -42,7 +48,14 @@ export class UserController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() user: UpdateUserDto,
+    @Request() req: ExpressRequest,
   ): Promise<Partial<User>> {
+    if (!req.user) throw new UnauthorizedException();
+    const currentUser = req.user as { id: number; role: UserRole };
+    // Only allow self-update or admin
+    if (currentUser.id !== id && currentUser.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('You can only update your own profile');
+    }
     const updated = await this.userService.update(id, user);
     if (!updated) throw new NotFoundException('User not found');
     return updated;
@@ -58,5 +71,17 @@ export class UserController {
     if (!user) throw new NotFoundException('User not found');
     await this.userService.remove(id);
     return { message: 'User deleted successfully' };
+  }
+
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @Patch(':id/role')
+  async updateRole(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: UpdateUserRoleDto,
+  ): Promise<Partial<User>> {
+    const updated = await this.userService.update(id, { role: body.role });
+    if (!updated) throw new NotFoundException('User not found');
+    return updated;
   }
 }


### PR DESCRIPTION
Introduces a new PATCH endpoint for updating user roles, restricted to admin users.

Enhances user profile update logic with access control, allowing only self-updates or admin actions.

Improves error handling with UnauthorizedException and ForbiddenException for unauthorized or forbidden operations.